### PR TITLE
修复无法跨设备创建链接bug

### DIFF
--- a/src/main/scala/com/gtan/repox/GetAsyncHandler.scala
+++ b/src/main/scala/com/gtan/repox/GetAsyncHandler.scala
@@ -4,6 +4,7 @@ import java.io.{FileOutputStream, File, OutputStream}
 import java.util.concurrent.atomic.AtomicBoolean
 
 import akka.actor.{ReceiveTimeout, PoisonPill, ActorRef}
+import com.gtan.repox.config.Config
 import com.gtan.repox.GetWorker._
 import com.gtan.repox.Head404Cache.NotFound
 import com.gtan.repox.data.Repo
@@ -82,7 +83,7 @@ class GetAsyncHandler(val uri: String, val repo: Repo, val worker: ActorRef, val
           tempFileOs = new FileOutputStream(tempFile)
           worker ! HeadersGot(headers)
         } else {
-          tempFile = File.createTempFile("repox", ".tmp")
+          val tempFile = newTempFile()
           tempFileOs = new FileOutputStream(tempFile)
           worker ! HeadersGot(headers)
           master.!(HeadersGot(headers))(worker)
@@ -107,6 +108,12 @@ class GetAsyncHandler(val uri: String, val repo: Repo, val worker: ActorRef, val
       tempFile.delete()
     }
     worker ! PoisonPill
+  }
+
+  private def newTempFile() = {
+    val parent = new File(Config.tempDirectory)
+    parent.mkdirs()
+    new File(parent, s"repox-${System.nanoTime}.tmp")
   }
 
 }

--- a/src/main/scala/com/gtan/repox/config/Config.scala
+++ b/src/main/scala/com/gtan/repox/config/Config.scala
@@ -12,6 +12,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.language.postfixOps
+import scala.util.Properties.userHome
 
 case class Config(proxies: Seq[ProxyServer],
                   repos: IndexedSeq[Repo],
@@ -20,6 +21,7 @@ case class Config(proxies: Seq[ProxyServer],
                   immediate404Rules: Seq[Immediate404Rule],
                   expireRules: Seq[ExpireRule],
                   storage: String,
+                  tempDirectory: String,
                   connectors: Set[Connector],
                   headTimeout: Duration,
                   headRetryTimes: Int)
@@ -107,7 +109,8 @@ object Config extends LazyLogging {
     proxyUsage = Map(),
     immediate404Rules = defaultImmediate404Rules,
     expireRules = defaultExpireRules,
-    storage = Paths.get(System.getProperty("user.home"), ".repox", "storage").toString,
+    storage = Paths.get(userHome, ".repox", "storage").toString,
+    tempDirectory = Paths.get(userHome, ".repox", "temp").toString,
     connectors = defaultConnectors,
     headTimeout = 3 seconds,
     headRetryTimes = 3
@@ -120,6 +123,8 @@ object Config extends LazyLogging {
   def get = instance.get()
 
   def storage: String = instance.get().storage
+
+  def tempDirectory: String = instance.get().tempDirectory
 
   def repos: Seq[Repo] = instance.get().repos
 


### PR DESCRIPTION
Archlinux/Centos运行报以下错误

```
 /tmp/repox8969815490132555300.tmp -> /home/jilen/.repox/storage: Invalid cross-device link 

java.nio.file.AtomicMoveNotSupportedException: /tmp/repox8969815490132555300.tmp -> /home/jilen/.repox/storage: Invalid cross-device link
    at sun.nio.fs.UnixCopyFile.move(UnixCopyFile.java:394) ~[na:1.8.0_25]
    at sun.nio.fs.UnixFileSystemProvider.move(UnixFileSystemProvider.java:262) ~[na:1.8.0_25]
    at java.nio.file.Files.move(Files.java:1395) ~[na:1.8.0_25]
    at com.gtan.repox.GetMaster$$anonfun$working$1.applyOrElse(GetMaster.scala:127) ~[com.gtan.repox-0.0.1.jar:0.0.1]
    at akka.actor.Actor$class.aroundReceive(Actor.scala:465) ~[com.typesafe.akka.akka-actor_2.11-2.3.7.jar:na]
    at com.gtan.repox.GetMaster.aroundReceive(GetMaster.scala:31) ~[com.gtan.repox-0.0.1.jar:0.0.1]
    at akka.actor.ActorCell.receiveMessage(ActorCell.scala:516) [com.typesafe.akka.akka-actor_2.11-2.3.7.jar:na]
    at akka.actor.ActorCell.invoke(ActorCell.scala:487) [com.typesafe.akka.akka-actor_2.11-2.3.7.jar:na]
    at akka.dispatch.Mailbox.processMailbox(Mailbox.scala:254) [com.typesafe.akka.akka-actor_2.11-2.3.7.jar:na]
    at akka.dispatch.Mailbox.run(Mailbox.scala:221) [com.typesafe.akka.akka-actor_2.11-2.3.7.jar:na]
    at akka.dispatch.Mailbox.exec(Mailbox.scala:231) [com.typesafe.akka.akka-actor_2.11-2.3.7.jar:na]
    at scala.concurrent.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260) [org.scala-lang.scala-library-2.11.4.jar:na]
    at scala.concurrent.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339) [org.scala-lang.scala-library-2.11.4.jar:na]
    at scala.concurrent.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979) [org.scala-lang.scala-library-2.11.4.jar:na]
    at scala.concurrent.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107) [org.scala-lang.scala-library-2.11.4.jar:na]
21:19:12.547 DEBUG com.gtan.repox.GetMaster akka://repox/user/RequestQueueMaster/GetQueueWorker_956930504/GetMaster_-692253683 
```
