### PR TITLE
Fix maven repo resolution failure when response code for HEAD is 204

### DIFF
--- a/src/main/scala/com/gtan/repox/HttpHelpers.scala
+++ b/src/main/scala/com/gtan/repox/HttpHelpers.scala
@@ -37,18 +37,19 @@ trait HttpHelpers { self: LazyLogging =>
   }
 
   def respondHead(exchange: HttpServerExchange, headers: ResponseHeaders): Unit = {
-    exchange.setStatusCode(StatusCodes.NO_CONTENT)
+    exchange.setStatusCode(200)
     val target = exchange.getResponseHeaders
     for ((k, v) <- headers)
       target.putAll(new HttpString(k), v)
     exchange.getResponseChannel // just to avoid mysterious setting Content-length to 0 in endExchange, ugly
+    exchange.setStatusCode(200)
     exchange.endExchange()
   }
 
   def immediateHead(resourceManager: ResourceManager, exchange: HttpServerExchange): Unit = {
     val uri = exchange.getRequestURI
     val resource = resourceManager.getResource(uri)
-    exchange.setStatusCode(StatusCodes.NO_CONTENT)
+    exchange.setStatusCode(200)
     val headers = exchange.getResponseHeaders
     headers.put(Headers.CONTENT_LENGTH, resource.getContentLength)
       .put(Headers.SERVER, "repox")

--- a/src/main/scala/com/gtan/repox/HttpHelpers.scala
+++ b/src/main/scala/com/gtan/repox/HttpHelpers.scala
@@ -42,7 +42,6 @@ trait HttpHelpers { self: LazyLogging =>
     for ((k, v) <- headers)
       target.putAll(new HttpString(k), v)
     exchange.getResponseChannel // just to avoid mysterious setting Content-length to 0 in endExchange, ugly
-    exchange.setStatusCode(200)
     exchange.endExchange()
   }
 


### PR DESCRIPTION
What changes proposed in this PR?

Currently, Repox returns status code 204 for `HEAD` request if the file can be found in Repox cache. The problem is that maven command `mvn` cannot parse this status code correctly. It reports failure like the following one. This PR changes the status code to 200 for successful `HEAD` request. 

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:1.0:enforce (enforce-maven) on project findbugs: Execution enforce-maven of goal org.apache.maven.plugins:maven-enforcer-plugin:1.0:enforce failed: 
Plugin org.apache.maven.plugins:maven-enforcer-plugin:1.0 or one of its dependencies could not be resolved: 
Failed to collect dependencies at org.apache.maven.plugins:maven-enforcer-plugin:jar:1.0 -> org.apache.maven:maven-artifact:jar:2.0.9: 
Failed to read artifact descriptor for org.apache.maven:maven-artifact:jar:2.0.9: Could not transfer artifact org.apache.maven:maven-artifact:pom:2.0.9 from/to nexus-osc (http://localhost:8078): 
Failed to transfer file: http://localhost:8078/org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9.pom. 

Return code is: 204, ReasonPhrase: No Content. -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginResolutionException
```
